### PR TITLE
Fixed bug with fallback to build/global.min.css

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -120,7 +120,7 @@ function silencio_scripts() {
         true
     );
 
-    if (defined('VIA_ENVIRONMENT') && VIA_ENVIRONMENT != 'dev') {
+    if (!defined('VIA_ENVIRONMENT') || (defined('VIA_ENVIRONMENT') && VIA_ENVIRONMENT != 'dev')) {
         wp_register_style(
             'global',
             get_template_directory_uri() . '/res/build/global.min.css',


### PR DESCRIPTION
There was a logic error where we didn't fallback to loading /res/build/global.min.css when VIA_ENVIRONMENT wasn't defined